### PR TITLE
Add Disqus support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ url:                 https://bincrafters.github.io
 
 # Set to '' when hosting a blog on GitHub Pages, ie on `//<username>.github.io`
 # Set to '/<reponame>' when using the `gh-pages` branch of a repository
-baseurl:             
+baseurl:
 
 # A very short description of your page
 tagline:             Collective information from Bincrafters team
@@ -18,8 +18,8 @@ tagline:             Collective information from Bincrafters team
 # A short description of the page, used in the sidebar and as fallback for the meta description tag.
 # Markdown enabled, but don't use more than one paragraph (enforced by `>`)
 description:         >
-  Bincrafters is a group of OSS developers with a shared interest in 
-  making binary software packages. 
+  Bincrafters is a group of OSS developers with a shared interest in
+  making binary software packages.
 
 # This should be the same author as first entry in `_data/authors.yml`
 author:
@@ -48,7 +48,7 @@ google_fonts:        Roboto+Slab:700|Noto+Sans:400,400i,700,700i
 google_analytics:    <UA-XXXXXXXX-X>
 
 # Setting a disqus shortname will enable the comment section on pages with `comments: true` in the front matter
-disqus_shortname:    
+disqus_shortname:   bincrafters
 
 # This text will appear in the footer of every page. Markdown enabled.
 copyright:           '&copy; 2017. All rights reserved.'

--- a/_posts/2017-05-01-bincrafters-package-disclaimers.md
+++ b/_posts/2017-05-01-bincrafters-package-disclaimers.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Bincrafters Packages - Disclaimers'
 tags: [Bintray, Conan.io]
+comments: true
 ---
 
 ## Licensing

--- a/_posts/2017-05-03-bintray-diverse-binary-hosting.md
+++ b/_posts/2017-05-03-bintray-diverse-binary-hosting.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Why we use Bintray'
 tags: [Bintray]
+comments: true
 ---
 
 Perhaps one can guess from the similarity in our name, but Bincrafters was largely inspired by Bintray.  Unlike the other services we use such as Github, Travis, and Appveyor, there was never really anything quite like Bintray.  Also, as of this writing, there aren't any alternatives that provide anything close to what Bintray does: a mature platform for hosting a wide range of repository types, storing all of the binary types that we create and use, with all the of the modern management features we need: user management, a solid API, etc. 

--- a/_posts/2017-05-25-go-tools-for-os-packaging.md
+++ b/_posts/2017-05-25-go-tools-for-os-packaging.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Cross-Platform Command-Line Toolset for OS Packaging'
 tags: [Bintray, Cross-Platform]
+comments: true
 ---
 A github user known as @mh-cbon has created a wonderful set of tools for packaging and general release management.  They are all written in Go, but they are all built and packaged as native binaries used at the CLI, so they can be used to package and release software written in any language.  The toolset can be found here:  [mh-cbon's Packaging Toolset - Overview and Tutorial](https://github.com/mh-cbon/go-github-release)
 

--- a/_posts/2017-06-06-using-bincrafters-conan-repository.md
+++ b/_posts/2017-06-06-using-bincrafters-conan-repository.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Using Bincrafters Public Conan Repository'
 tags: [Conan.io, Bintray, C++]
+comments: true
 ---
 
 Bincrafters is posting new packages and/or versions to our public Conan repository every week. We've provided some instructions below for users who wish to start using them. 

--- a/_posts/2017-06-21-jfrog-cli-for-bintray.md
+++ b/_posts/2017-06-21-jfrog-cli-for-bintray.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Using the JFrog CLI for Bintray'
 tags: [Bintray]
+comments: true
 ---
 
 The JFrog CLI can be used with all of JFrog's products: Artifactory, Bintray, Mission Control, and Xray.  This post focuses on it's usefulness to Bintray users who are in the business of packaging and uploading binaries on a regular basis. 

--- a/_posts/2017-07-01-bintray-entitlements-for-licensing.md
+++ b/_posts/2017-07-01-bintray-entitlements-for-licensing.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Bintray Entitlements - A Modern Way to Profit on Code'
 tags: [Bintray]
+comments: true
 ---
 
 If you make modern applications or software libraries and are having difficulty with the "profit" part, the Bintray entitlements system might be able to help you. 

--- a/_posts/2017-07-15-Microsoft-CPPRest-testing.md
+++ b/_posts/2017-07-15-Microsoft-CPPRest-testing.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Conan Package - Microsoft CPPRest SDK - Available for Testing'
 tags: [C++, Conan.io]
+comments: true
 ---
 
 A new package is now available on the [Bincrafters Public Conan Repository](https://bintray.com/bincrafters/public-conan): Microsoft's "CPPRest SDK".  Formerly known as "Casablanca", the CPPRest SDK is one of the most stable and mature REST libraries for C++.  It is a solid library for interacting with any REST API, not just those provided by Microsoft.  For instructions on using Bincrafters `public-conan` repository, [please see this post](2017-06-06-using-bincrafters-conan-repository.md).

--- a/_posts/2017-08-11-real-world-packaging-conan.md
+++ b/_posts/2017-08-11-real-world-packaging-conan.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Real-World Packaging C++ with Conan.io'
 tags: [Conan.io, C++]
+comments: true
 ---
 
 Over the past year, each member of the Bincrafters team has worked extensively with the Conan platform on packaging a diverse array of C and C++ libraries.   We've had the opportunity to dig very deep into advanced features such as custom generators, conan package tools for CI automation, and a great deal of debugging.  Here are some of the things we've learned about advanced packaging at scale.  

--- a/_posts/2017-08-26-azure-iot-sdk-c-testing.md
+++ b/_posts/2017-08-26-azure-iot-sdk-c-testing.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Conan Package - Azure IOT SDK for C - Available for Testing'
 tags: [C++, Conan.io]
+comments: true
 ---
 
 A new package is now available on the [Bincrafters Public Conan Repository](https://bintray.com/bincrafters/public-conan): "The Azure IOT SDK for C" published by Microsoft.  It is a pure C library for communicating with Microsoft Azure's IOTHub platform, and features a collection of other pure C libraries for things like MQTT, AMQP, JSON Parsing, etc.  Each library is packaged separately with Conan, and the dependency tree is expressed appropriately in each recipes. For instructions on using these libraries from our repository, [please see this post](2017-06-06-using-bincrafters-conan-repository.md).

--- a/_posts/2017-09-09-trello-board-for-contributors.md
+++ b/_posts/2017-09-09-trello-board-for-contributors.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Public Trello Board - Need Contributors'
 tags: [C++, Conan.io, Boost]
+comments: true
 ---
 
 We've added a [New Trello Board](https://trello.com/b/iFeFCPwa) to house all the packages that we discover we need to create some day to serve as dependencies, but that we don't really have time to build right now.  We hope that community members can work on these over time. 

--- a/_posts/2017-09-22-boost-modular-packages-conan.md
+++ b/_posts/2017-09-22-boost-modular-packages-conan.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Boost 1.64.0 - Modular Packages on Conan.io'
 tags: [C++, Conan.io, Bintray, Boost]
+comments: true
 ---
 
 Starting with Boost 1.64.0, the Bincrafters team will now publish each of the Boost C++ libraries as separate packages on Conan.io. With this, developers can now reference the specific Boost libraries they want to use as dependencies rather than referencing the entire Boost collection. 

--- a/_posts/2017-10-02-Conan-Package-Java.md
+++ b/_posts/2017-10-02-Conan-Package-Java.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Conan Package - Java 8 and 9 installers'
 tags: [C++, Conan.io, Bintray]
+comments: true
 ---
 
 Bincrafters has now published Conan packages for both the Java 8 and Java 9 installers to our public Conan repository on Bintray.  Indeed it's a bit surprising to have a need to package Java with Conan.io, but it turns out that there are C++ related tools which require Java.  The tool that prompted this package was Google's open-source build system Bazel, which uses Java to compile C++.  Thus, it is primarily intended to be used as a `build_requirement` in a Conan recipe. 

--- a/_posts/2017-10-03-Conan-Package-Bazel.md
+++ b/_posts/2017-10-03-Conan-Package-Bazel.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Conan Package - Bazel'
 tags: [C++, Conan.io, Bintray]
+comments: true
 ---
 
 Bincrafters has now published a Conan package for Google's open-source build system "Bazel" to our public Conan repository on Bintray. Bazel is used as the build system in a number of Google's popular C++ projects, including Abseil, Protobuf, Tensorflow, and others.  It is primarily intended to be used as a `build_requirement` in Conan recipes for these projects.  

--- a/_posts/2017-10-04-Conan-Package-Abseil.md
+++ b/_posts/2017-10-04-Conan-Package-Abseil.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Conan Package - Abseil'
 tags: [C++, Conan.io, Bintray]
+comments: true
 ---
 
 Bincrafters has now published a Conan package for Google's open-source library "Abseil" to our public Conan repository on Bintray. Abseil was just announced by Titus Winters last week at CPPCon 2017, and provides a number of mature utililty types and functions.  Abseil is a bit unique in that Google has chosen not to implement semantic versioning and promote the use of the library strictly by following the master branch of their GIT repository, a strategy described by Winters as "Live at Head."

--- a/_posts/2017-10-05-Conan-Package-MSYS2.md
+++ b/_posts/2017-10-05-Conan-Package-MSYS2.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Conan Package - MSYS2'
 tags: [C++, Conan.io, Bintray]
+comments: true
 ---
 
 MSYS2 is software distribution and a building platform for Windows. It provides a Unix-like environment, a command-line interface and a software repository making it easier to install, use, build and port software on Windows. Many C++ projects are setup to be built with MSYS2 when built on Windows, rather than MSBuild. It is primarily intended to be used as a `build_requirement` in Conan recipes for these projects.  One project that requires MSYS2 to build from sources is Google's build system Bazel. 

--- a/_posts/2017-10-10-Bincrafters-Conan-Center.md
+++ b/_posts/2017-10-10-Bincrafters-Conan-Center.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Bincrafters Packages and Conan Center'
 tags: [C++, Conan.io, Bintray]
+comments: true
 ---
 
 "Conan Center" is the moderated central repository for Conan packages hosted by Bintray.  With Conan Center, community members need only to check a box on their package in the web portal and it will be submitted for moderation and inclusion.  This strategy is very elegant, and actually has been used to great success for several years with their moderated central maven respository for Java packages known as "JCenter".  

--- a/_posts/2017-10-11-Conan-Package-Boost-1-65-1.md
+++ b/_posts/2017-10-11-Conan-Package-Boost-1-65-1.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Conan Packages - Boost v1.65.1'
 tags: [C++, Conan.io, Boost, Bintray]
+comments: true
 ---
 
 A few weeks ago, we announced a set of [Modular Packages on Conan.io for the Boost C++ Libraries](https://bincrafters.github.io/2017/09/22/boost-modular-packages-conan/).  The original set of packages included Boost v1.64.0 only, and we've been working ever since to finish packaging v1.65.1.  We are happy to announce that the v1.65.1 packages are now available in the [Bincrafters public repository](https://bintray.com/bincrafters/public-conan).  

--- a/_posts/2017-10-17-Conan-Package-CPPRestSDK.md
+++ b/_posts/2017-10-17-Conan-Package-CPPRestSDK.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Conan Package - Microsoft C++ REST SDK'
 tags: [C++, Conan.io, Bintray]
+comments: true
 ---
 
 Bincrafters has now published a Conan package for Microsoft C++ REST SDK to our public Conan repository on Bintray. It is a project which offers both HTTP client and server functionality, including websockets support.  It features a modern asynchronous API design in C++ with Boost Asio.  It is cross-platform, supporting Windows, Linux, and Mac, as well as IOS and Android.  The C++ REST SDK is widely used among C++ projects which have need to interact with REST services.  [A swagger generator for the C++ REST SDK](https://github.com/swagger-api/swagger-codegen/tree/master/samples/client/petstore/cpprest) has also been constructed by the community, which can generate the C++ code needed to compile a strongly-typed C++ SDK for any REST API that publishes a swagger specifications.  This makes it an obvious choice for interacting with any such REST API. 

--- a/_posts/2017-10-19-Conan-Package-ICU.md
+++ b/_posts/2017-10-19-Conan-Package-ICU.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Conan Package - IBM ICU'
 tags: [C++, Conan.io, Bintray]
+comments: true
 ---
 
 Bincrafters has now published a Conan package for IBM's open-source libraries known as "ICU" to our public Conan repository on Bintray. ICU stands for "International Components for Unicode" and is a mature and portable set of libraries for software internationalization (I18N) and globalization (G11N) which implement the Unicode Standard, giving applications the same results on all platforms.

--- a/_posts/2017-11-06-Bincrafters-Status-Update.md
+++ b/_posts/2017-11-06-Bincrafters-Status-Update.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Bincrafters Status Update'
 tags: []
+comments: true
 ---
 
 We've received a lot of really great feedback from the C++ community about the Conan packages we've been publishing over the past few months. We are really grateful to the community and the Conan team for the support, and we had a few other updates we wanted to share. 

--- a/_posts/2017-11-08-Bincrafters-Shoutouts.md
+++ b/_posts/2017-11-08-Bincrafters-Shoutouts.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Bincrafters Shoutouts'
 tags: [Conan.io, Bintray]
+comments: true
 ---
 
 The Bincrafters team recently hit double digits, which feels like a big accomplishment for us.  Each member has brought a unique combination of experience, insight, and Conan recipe's to the table.  This has allowed us to start checking multiple packages off our list each week for the last two months.  It's also allowed us to level-up our packaging game in a few cases. This post is just to highlight how valuable and appreciated everyone's time is, before we start on a next trial of strength... packaging Qt. 

--- a/_posts/2017-11-10-Updated-Conan-Package-Flow.md
+++ b/_posts/2017-11-10-Updated-Conan-Package-Flow.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Updated Conan Package Flow'
 tags: [Conan.io]
+comments: true
 ---
 
 With the latest version of Conan, Bincrafters had to rethink our common workflows for developing packages.  We were a bit confused at first, and had to ask the Conan team for advice to get things streamlined. We wanted to share the current workflow with the community in case other packagers are also struggling to figure out the best flow with the updated command-line options.  

--- a/_posts/2017-11-15-Conan-Packages-for-Native-Binaries.md
+++ b/_posts/2017-11-15-Conan-Packages-for-Native-Binaries.md
@@ -2,6 +2,7 @@
 layout: post
 title: 'Packaging Native Binaries'
 tags: [C++, Conan.io]
+comments: true
 ---
 
 In the realm of software development, managing libraries in precompiled binary format is non-trivial.  Java jars and .NET nupkgs have a fair bit of flexibility and customizability, and with flexibility comes complexity.  However, the complexity surrounding these intermediate binaries pales in comparison to that surrounding precompiled native binaries.  This complexity is so overwhelming, that historically it was considered impossible or at least impractical by most.  This post highlights a few of the dimensions of complexity which exist when packaging native binaries, and explains the modern and innovative approach used by Conan.io to address them.  While this post is focused on C++ as a use-case, much of it applies to other native languages as well, including Rust, Go, D, and so on. 

--- a/_posts/2017-11-20-Continuous-Integration-Sponsorship.md
+++ b/_posts/2017-11-20-Continuous-Integration-Sponsorship.md
@@ -2,31 +2,32 @@
 layout: post
 title: 'Seeking CI Sponsorship'
 tags: [C++, Conan.io]
+comments: true
 ---
 
-Bincrafters is dedicated to creating, publishing, and maintaining Conan packages for important C/C++ libraries for the foreseeable future. On the horizon are some massive multi-library projects including Qt, as well as OpenCV and others. We're still trying to figure out all the logistics for those packages, but one thing is for sure: __CI has become a significant bottleneck to our packaging__. As such, we're looking for organizations who would be willing to provide recurring sponsorship for professional accounts on Travis CI and Appveyor, and Bintray. 
+Bincrafters is dedicated to creating, publishing, and maintaining Conan packages for important C/C++ libraries for the foreseeable future. On the horizon are some massive multi-library projects including Qt, as well as OpenCV and others. We're still trying to figure out all the logistics for those packages, but one thing is for sure: __CI has become a significant bottleneck to our packaging__. As such, we're looking for organizations who would be willing to provide recurring sponsorship for professional accounts on Travis CI and Appveyor, and Bintray.
 
 ## Free CI Services for OSS
-Travis, Appveyor, and Bintray all provide amazing public services for free.  We don't know how they do it, but we're grateful. It is these services which have enabled Bincrafters to exist in the first place.  We've been hitting the ceiling with each of these services on a regular basis, and engineered around them as best we could.  With free plans, Appveyor runs 1 concurrent job, Travis runs a few for linux, but Mac builds are bottlenecked to 2.  Also, Mac builds have regularly experienced issues which have caused them to be delayed multiple days.   In the face of continued growth, the limitations are simply untenable. 
+Travis, Appveyor, and Bintray all provide amazing public services for free.  We don't know how they do it, but we're grateful. It is these services which have enabled Bincrafters to exist in the first place.  We've been hitting the ceiling with each of these services on a regular basis, and engineered around them as best we could.  With free plans, Appveyor runs 1 concurrent job, Travis runs a few for linux, but Mac builds are bottlenecked to 2.  Also, Mac builds have regularly experienced issues which have caused them to be delayed multiple days.   In the face of continued growth, the limitations are simply untenable.
 
 As all the paid plans are tailored for non-OSS use, we have recently reached out to both Appveyor and Travis asking for custom pricing.  
 
 Appveyor has responded with the following custom OSS pricing:  
 > *Plans for OSS projects start from “Premium FOSS” $49.50/month for 2 concurrent jobs and then each additional job is +$25/month to that price.*
 
-Travis has not responded yet. 
+Travis has not responded yet.
 
-For Bintray, $150.00 / month will give us everything we need. 
+For Bintray, $150.00 / month will give us everything we need.
 
 ## Total Monthly Funding Target
-For paid plans on each of these services which would increase our concurrent build capacity in a meaningful way, we will need __a total of approximately $500 USD each month__.  We don't expect any single organization to contribute this amount.  Instead we are hoping to find several organizations who can commit to smaller monthly contributions. 
+For paid plans on each of these services which would increase our concurrent build capacity in a meaningful way, we will need __a total of approximately $500 USD each month__.  We don't expect any single organization to contribute this amount.  Instead we are hoping to find several organizations who can commit to smaller monthly contributions.
 
 ## In Return for Contribution
-We want to show appreciation for any amount of financial support, so we have added a section on [the About page on our blog](https://bincrafters.github.io/about/) to feature, thank, and promote such sponsors.  As with any charitable donation, the idea behind showcasing sponsors publicly is that it might help bring positive attention to those sponsors, and possibly even business. 
+We want to show appreciation for any amount of financial support, so we have added a section on [the About page on our blog](https://bincrafters.github.io/about/) to feature, thank, and promote such sponsors.  As with any charitable donation, the idea behind showcasing sponsors publicly is that it might help bring positive attention to those sponsors, and possibly even business.
 
 ## How to Contribute
-If you represent an organization who is interested in sponsoring, please reach out to us via email using our __bincrafters gmail account__. 
+If you represent an organization who is interested in sponsoring, please reach out to us via email using our __bincrafters gmail account__.
 
 
 ## Other Support
-We also want to let the community of followers on Twitter and elsewhere that your support and promotion also matters, both on social media, and locally among developers you know or work with.  The rate of adoption and improvement with both Conan and Bincrafters is significantly impacted by word-of-mouth communication, coming from developers who actually use and enjoy Conan.  So, continued thanks to our users. 
+We also want to let the community of followers on Twitter and elsewhere that your support and promotion also matters, both on social media, and locally among developers you know or work with.  The rate of adoption and improvement with both Conan and Bincrafters is significantly impacted by word-of-mouth communication, coming from developers who actually use and enjoy Conan.  So, continued thanks to our users.


### PR DESCRIPTION
Hi!

I just added Disqus support to anyone give some feedback directly on blog.

Only `comments: true` and `discus_shortname: bincrafters` were added by me, any other changes were made by text editor.

Regards!